### PR TITLE
Add "tags" strategy option for smart extract strategy

### DIFF
--- a/man/osmium-extract.md
+++ b/man/osmium-extract.md
@@ -366,19 +366,31 @@ Strategy **smart_by_first_node_and_tags**
 For the **complete_ways** strategy you can set the option "-S relations=false"
 in which case no relations will be written to the output file.
 
-For the **smart** strategy you can change the types of relations that should be
+The **smart** strategy allows the following strategy options:
+
+Use "-S types=TYPE,..." to change the types of relations that should be
 reference-complete. Instead of just relations tagged "type=multipolygon", you
 can either get all relations (use "-S types=any") or give a list of types to
 the -S option: "-S types=multipolygon,route". Note that especially boundary
 relations can be huge, so if you include them, be aware your result might be
 huge.
 
-The **smart** strategy allows another option "-S complete-partial-relations=X".
-If this is set, all relations that have more than X percent of their members
-already in the extract will have their full set of members in the extract. So
-this allows completing almost complete relations. It can be useful for instance
-to make sure a boundary relation is complete even if some of it is outside the
-polygon used for extraction.
+Use "-S complete-partial-relations=X" to force completion of partly completed
+relations. If this is set, all relations that have more than X percent of their
+members already in the extract will have their full set of members in the
+extract. So this allows completing almost complete relations. It can be useful
+for instance to make sure a boundary relation is complete even if some of it is
+outside the polygon used for extraction.
+
+Use "-S tags=PATTERN,..." to only complete relations that have a tag matching
+one of the PATTERNs. So for example if you use "-S
+tags=landuse,natural=wood,natural=water" everything tagged `landuse=*` or
+`natural=wood` or `natural=water` is added to the result, but no other
+relations.
+
+You can combine the "-S types", "-S complete-partial-relations", and "-S tags"
+options. The options will be interpreted as "(types OR
+complete-partial-relations) AND tags".
 
 The **complete_ways_by_first_node_and_tags** and **smart_by_first_node_and_tags**
 strategies allow to define include_tags and exclude_tags.

--- a/man/osmium-extract.md
+++ b/man/osmium-extract.md
@@ -392,6 +392,16 @@ You can combine the "-S types", "-S complete-partial-relations", and "-S tags"
 options. The options will be interpreted as "(types OR
 complete-partial-relations) AND tags".
 
+For the **smart_by_first_node_and_tags** strategy  you can set the option
+"-S tags=PATTERN,...", however, it works differently compare to **smart** 
+strategy. In this strategy, the combination of "types" and "tags" options
+includes result of both matches, for example, of the matched relation has
+a type=multipolygon and a tag maritime=yes, and the query contains options
+like: "-S types=road_acess -S tags=maritime=yes" then normally the relation
+won't be processed, as it's type differs from declared options, but with 
+smart_by_first_node_and_tags the relation will be processed.
+ 
+
 The **complete_ways_by_first_node_and_tags** and **smart_by_first_node_and_tags**
 strategies allow to define include_tags and exclude_tags.
 They are onl supported when using **config file**, and they should be defined on

--- a/src/extract/strategy_smart.hpp
+++ b/src/extract/strategy_smart.hpp
@@ -27,6 +27,7 @@ along with this program.  If not, see <https://www.gnu.org/licenses/>.
 
 #include <osmium/index/id_set.hpp>
 #include <osmium/index/relations_map.hpp>
+#include <osmium/tags/tags_filter.hpp>
 
 #include <memory>
 #include <string>
@@ -59,8 +60,12 @@ namespace strategy_smart {
 
         std::size_t m_complete_partial_relations_percentage = 100;
 
+        std::vector<std::string> m_filter_tags;
+        osmium::TagsFilter m_filter{true};
+
         bool check_members_count(const std::size_t size, const std::size_t wanted_members) const noexcept;
         bool check_type(const osmium::Relation& relation) const noexcept;
+        bool check_tags(const osmium::Relation& relation) const noexcept;
 
     public:
 

--- a/src/extract/strategy_smart_by_first_node_and_tags.cpp
+++ b/src/extract/strategy_smart_by_first_node_and_tags.cpp
@@ -203,7 +203,7 @@ namespace strategy_smart_by_first_node_and_tags {
                         if (e->node_ids.get(member.positive_ref())) {
                             if (wanted_members == 0) {
                                 e->relation_ids.set(relation.positive_id());
-                                if (strategy().check_type(relation) && strategy().check_tags(relation)) {
+                                if (strategy().check_type(relation) || strategy().check_tags(relation)) {
                                     e->add_relation_members(relation);
                                     return;
                                 }
@@ -215,7 +215,7 @@ namespace strategy_smart_by_first_node_and_tags {
                         if (e->way_ids.get(member.positive_ref())) {
                             if (wanted_members == 0) {
                                 e->relation_ids.set(relation.positive_id());
-                                if (strategy().check_type(relation) && strategy().check_tags(relation)) {
+                                if (strategy().check_type(relation) || strategy().check_tags(relation)) {
                                     e->add_relation_members(relation);
                                     return;
                                 }

--- a/src/extract/strategy_smart_by_first_node_and_tags.cpp
+++ b/src/extract/strategy_smart_by_first_node_and_tags.cpp
@@ -25,6 +25,7 @@ along with this program.  If not, see <https://www.gnu.org/licenses/>.
 #include "../util.hpp"
 
 #include <osmium/handler/check_order.hpp>
+#include <osmium/tags/taglist.hpp>
 #include <osmium/util/misc.hpp>
 #include <osmium/util/string.hpp>
 
@@ -78,6 +79,19 @@ namespace strategy_smart_by_first_node_and_tags {
                         m_complete_partial_relations_percentage = 100;
                     }
                 }
+            } else if (option.first == "tags") {
+                m_filter_tags = osmium::split_string(option.second, ',', true);
+                m_filter.set_default_result(false);
+                for (const auto &tag : m_filter_tags) {
+                    const auto pos = tag.find('=');
+                    if (pos == std::string::npos) {
+                        m_filter.add_rule(true, osmium::TagMatcher{tag});
+                    } else {
+                        const auto key = tag.substr(0, pos);
+                        const auto value = tag.substr(pos + 1);
+                        m_filter.add_rule(true, osmium::TagMatcher{key, value});
+                    }
+                }
             } else {
                 warning(std::string{"Ignoring unknown option '"} + option.first + "' for 'smart_by_first_node_and_tags' strategy.\n");
             }
@@ -105,6 +119,10 @@ namespace strategy_smart_by_first_node_and_tags {
         return it != m_types.end();
     }
 
+    bool Strategy::check_tags(const osmium::Relation& relation) const noexcept {
+        return osmium::tags::match_any_of(relation.tags(), m_filter);
+    }
+
     void Strategy::show_arguments(osmium::VerboseOutput& vout) {
         vout << "Additional strategy options:\n";
         if (m_types.empty()) {
@@ -123,6 +141,18 @@ namespace strategy_smart_by_first_node_and_tags {
             vout << "  - [complete-partial-relations] do not complete partial relations\n";
         } else {
             vout << "  - [complete-partial-relations] complete partial relations when " << m_complete_partial_relations_percentage << "% or more members are in extract\n";
+        }
+        if (m_filter_tags.empty()) {
+            vout << "  - [tags] no tags defined\n";
+        } else {
+            std::string filterlist;
+            for (const auto& tag : m_filter_tags) {
+                if (!filterlist.empty()) {
+                    filterlist += ",";
+                }
+                filterlist += tag;
+            }
+            vout << "  - [tags] " << filterlist << '\n';
         }
         vout << '\n';
     }
@@ -173,7 +203,7 @@ namespace strategy_smart_by_first_node_and_tags {
                         if (e->node_ids.get(member.positive_ref())) {
                             if (wanted_members == 0) {
                                 e->relation_ids.set(relation.positive_id());
-                                if (strategy().check_type(relation)) {
+                                if (strategy().check_type(relation) && strategy().check_tags(relation)) {
                                     e->add_relation_members(relation);
                                     return;
                                 }
@@ -185,7 +215,7 @@ namespace strategy_smart_by_first_node_and_tags {
                         if (e->way_ids.get(member.positive_ref())) {
                             if (wanted_members == 0) {
                                 e->relation_ids.set(relation.positive_id());
-                                if (strategy().check_type(relation)) {
+                                if (strategy().check_type(relation) && strategy().check_tags(relation)) {
                                     e->add_relation_members(relation);
                                     return;
                                 }
@@ -198,7 +228,7 @@ namespace strategy_smart_by_first_node_and_tags {
                 }
             }
 
-            if (strategy().check_members_count(relation.members().size(), wanted_members)) {
+            if (strategy().check_members_count(relation.members().size(), wanted_members) && strategy().check_tags(relation)) {
                 e->add_relation_members(relation);
             }
         }

--- a/src/extract/strategy_smart_by_first_node_and_tags.hpp
+++ b/src/extract/strategy_smart_by_first_node_and_tags.hpp
@@ -61,7 +61,7 @@ namespace strategy_smart_by_first_node_and_tags {
         std::size_t m_complete_partial_relations_percentage = 100;
 
         std::vector<std::string> m_filter_tags;
-        osmium::TagsFilter m_filter{true};
+        osmium::TagsFilter m_filter{false};
 
         bool check_members_count(const std::size_t size, const std::size_t wanted_members) const noexcept;
         bool check_type(const osmium::Relation& relation) const noexcept;

--- a/src/extract/strategy_smart_by_first_node_and_tags.hpp
+++ b/src/extract/strategy_smart_by_first_node_and_tags.hpp
@@ -27,6 +27,7 @@ along with this program.  If not, see <https://www.gnu.org/licenses/>.
 
 #include <osmium/index/id_set.hpp>
 #include <osmium/index/relations_map.hpp>
+#include <osmium/tags/tags_filter.hpp>
 
 #include <memory>
 #include <string>
@@ -59,8 +60,12 @@ namespace strategy_smart_by_first_node_and_tags {
 
         std::size_t m_complete_partial_relations_percentage = 100;
 
+        std::vector<std::string> m_filter_tags;
+        osmium::TagsFilter m_filter{true};
+
         bool check_members_count(const std::size_t size, const std::size_t wanted_members) const noexcept;
         bool check_type(const osmium::Relation& relation) const noexcept;
+        bool check_tags(const osmium::Relation& relation) const noexcept;
 
     public:
 


### PR DESCRIPTION
This checks relations for the specified keys/tags. For a relation to be completed it has to match the keys/tags.

Use something like this: -S tags=landuse,natural=wood,natural=water This would match everything tagged landuse=* or natural=wood or natural=water.